### PR TITLE
Fix bug with `@tail.next` after `pop` element

### DIFF
--- a/lib/linked-list/list.rb
+++ b/lib/linked-list/list.rb
@@ -166,7 +166,7 @@ module LinkedList
     def __pop
       tail = @tail
       @tail = @tail.prev
-      @tail.prev = nil if @tail
+      @tail.next = nil if @tail
       tail
     end
 

--- a/test/list_test.rb
+++ b/test/list_test.rb
@@ -125,6 +125,13 @@ describe LinkedList::List do
       list.pop
       assert_equal 0, list.length
     end
+
+    it 'maintains list when multiple nodes are removed' do
+      list.push(node_1)
+      list.push(node_2)
+      list.pop
+      assert_equal [node_1.data], list.to_a
+    end
   end
 
   describe '#shift' do


### PR DESCRIPTION
Fix a bug when setting the `@tail.next` element to `nil`, since it was
mistakenly setting `@tail.prev` to `nil` instead, which in turn caused
problems when evaluating its list of data after popping several elements
without knowing their correct previous element.

An example of the bug it causes is as follows:

```ruby
require "linked-list"

object = Object.new # could be anything
list = LinkedList::List.new

list.push(object)
list << object # same as `push`
list.to_a # => [#<Object:0x00007fddbb0510e0>, #<Object:0x00007fddbb0510e0>]

list.pop # => #<Object:0x00007fddbb0510e0>
list.to_a # => [#<Object:0x00007fddbb0510e0>, #<Object:0x00007fddbb0510e0>]

list.pop # => #<Object:0x00007fddbb0510e0>
list.to_a # => []
```